### PR TITLE
Extend Util.php to accept rdfxml in getParser and getSerializer

### DIFF
--- a/src/quickRdfIo/Util.php
+++ b/src/quickRdfIo/Util.php
@@ -82,6 +82,7 @@ class Util {
             'application/n-quads' => new NQuadsSerializer(),
             'xml',
             'rdf',
+            'rdfxml', // EasyRdf is using it in Format::guessFormat
             'application/rdf+xml',
             'text/rdf',
             'application/xml',
@@ -135,6 +136,7 @@ class Util {
             'application/n-quads' => new NQuadsParser($dataFactory, false, NQuadsParser::MODE_QUADS_STAR),
             'xml',
             'rdf',
+            'rdfxml', // EasyRdf is using it in Format::guessFormat
             'application/rdf+xml',
             'text/rdf',
             'application/xml',

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -44,6 +44,16 @@ class UtilTest extends \PHPUnit\Framework\TestCase {
         self::$dfSimple = new \simpleRdf\DataFactory();
     }
 
+    public function testGetParser(): void {
+        $parser = Util::getParser('rdfxml', self::$dfQuick);
+        $this->assertTrue($parser instanceof RdfXmlParser);
+    }
+
+    public function testGetSerializer(): void {
+        $serializer = Util::getSerializer('rdfxml');
+        $this->assertTrue($serializer instanceof RdfXmlSerializer);
+    }
+
     public function testParse(): void {
         $url     = 'https://www.w3.org/2000/10/rdf-tests/RDF-Model-Syntax_1.0/ms_7.2_1.rdf';
         $client  = new \GuzzleHttp\Client();


### PR DESCRIPTION
This patch makes Util::getParser and Util::getSerializer compatible with EasyRdf's Format::guessFormat return value for RDF/XML.