### PR TITLE
PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" displayDetailsOnTestsThatTriggerDeprecations="true">
   <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>

--- a/src/quickRdfIo/RdfXmlParser.php
+++ b/src/quickRdfIo/RdfXmlParser.php
@@ -222,9 +222,6 @@ class RdfXmlParser implements iParser, iQuadIterator {
         if ($this->input->tell() !== 0) {
             $this->input->rewind();
         }
-        if (isset($this->parser)) {
-            xml_parser_free($this->parser);
-        }
         $this->nmsp       = [];
         $this->elementIds = [];
         $this->state      = new RdfXmlParserState();


### PR DESCRIPTION
**Summary:**
- Added PHP 8.5 to testing matrix in workflows/test.yml
- fixed a deprecation regarding `xml_parser_free()`
- added `displayDetailsOnTestsThatTriggerDeprecations` to phpunit.xml to see deprecations in the test suite
- all other deprecations are because of other libraries