### PR TITLE
Replace ml/json-ld with sweetrdf/json-ld

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "sweetrdf/rdf-interface": "^3.2",
         "sweetrdf/rdf-helpers": "^2",
         "pietercolpaert/hardf": ">=0.3.1 <1",
-        "ml/json-ld": "^1.2"
+        "sweetrdf/json-ld": "^1.3"
     },
     "suggest": {
         "sweetrdf/quick-rdf": "*"


### PR DESCRIPTION
I just wanted to check if you would consider replacing `ml/json-ld` with `sweetrdf/json-ld`. It should be a drop-in replacement but requires at least **PHP 8.1**.